### PR TITLE
Fixing workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image for Dev Branch
+name: Dev Branch Release
 
 on:
     push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Image
+name: Main Branch Release
 
 on:
     release:
@@ -29,7 +29,7 @@ jobs:
               with:
                   images: zbejas/orbiscast
                   tags: |
-                      type=ref,event=release
+                      type=semver,pattern={{version}}
 
             - name: Build and push Docker image
               id: push


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows for building and releasing Docker images. The main changes involve renaming the workflows and updating the tagging pattern for Docker images.

Changes to GitHub workflows:

* [`.github/workflows/dev.yml`](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddL1-R1): Renamed the workflow from "Build Docker Image for Dev Branch" to "Dev Branch Release".
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-R1): Renamed the workflow from ".github/workflows/release.yml" to ".github/workflows/main.yml" and updated the name from "Publish Docker Image" to "Main Branch Release".
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L32-R32): Updated the Docker image tagging pattern from `type=ref,event=release` to `type=semver,pattern={{version}}`.