### PR TITLE
More fixes for workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,7 @@ jobs:
               uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
               with:
                   images: zbejas/orbiscast
-                  tags: |
-                      type=semver,pattern={{version}}
+                  tags: latest
 
             - name: Build and push Docker image
               id: push

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # OrbisCast
 
-[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/docker-image.yml)](https://github.com/zbejas/orbiscast/actions/workflows/docker-image.yml)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/main.yml?label=main%20build)](https://hub.docker.com/repository/docker/zbejas/orbiscast/tags)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/dev.yml?label=dev%20build)](https://hub.docker.com/repository/docker/zbejas/orbiscast/tags)
 [![GitHub last commit](https://img.shields.io/github/last-commit/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/pulls)
 [![GitHub license](https://img.shields.io/github/license/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/blob/main/LICENSE.md)
-[![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/zbejas/orbiscast)](https://hub.docker.com/r/zbejas/orbiscast)
+[![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/zbejas/orbiscast?sort=date)](https://hub.docker.com/r/zbejas/orbiscast)
 [![Docker Pulls](https://img.shields.io/docker/pulls/zbejas/orbiscast)](https://hub.docker.com/r/zbejas/orbiscast)
 
 **OrbisCast** is a Discord bot that streams IPTV channels. It can be controlled by users with [commands](#commands) specified at the end of this document.


### PR DESCRIPTION
This pull request includes updates to the Docker image tagging process and improvements to the `README.md` badges for better clarity and functionality.

### Docker Image Tagging:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L31-R31): Changed the Docker image tags from a semantic versioning pattern to use the `latest` tag.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9): Updated the GitHub build status badges to differentiate between the main and development builds and adjusted the Docker image size badge to sort by date.