### PR TITLE
final fix?

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,3 @@ jobs:
 
             - name: Generate artifact attestation
               uses: actions/attest-build-provenance@v2
-              with:
-                  subject-name: index.docker.io/zbejas/orbiscast
-                  subject-digest: ${{ steps.push.outputs.digest }}
-                  push-to-registry: true


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main.yml` file. The change removes unnecessary parameters from the `Generate artifact attestation` step to simplify the workflow.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L45-L48): Removed `subject-name`, `subject-digest`, and `push-to-registry` parameters from the `Generate artifact attestation` step.