### PR TITLE
Removed the whole actual job this time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,3 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-
-            - name: Generate artifact attestation
-              uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/main.yml` file. The change removes the step for generating artifact attestation from the workflow.

Workflow simplification:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L42-L44): Removed the step that uses `actions/attest-build-provenance@v2` to generate artifact attestation.