### PR TITLE
added actual version tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,9 @@ jobs:
               uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
               with:
                   images: zbejas/orbiscast
-                  tags: latest
+                  tags: |
+                      latest
+                      ${{ github.event.release.tag_name }}
 
             - name: Build and push Docker image
               id: push


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/main.yml` file to enhance the Docker image tagging process.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L31-R33): Modified the `tags` section to include both `latest` and the release tag name from the GitHub event.