### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OrbisCast
 
-[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/main.yml?label=main%20build)](https://hub.docker.com/r/zbejas/orbiscast/tags)
-[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/dev.yml?label=dev%20build)](https://hub.docker.com/r/zbejas/orbiscast/tags)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/main.yml?label=main%20build)](https://hub.docker.com/r/zbejas/orbiscast/tags?ordering=name)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/dev.yml?label=dev%20build)](https://hub.docker.com/r/zbejas/orbiscast/tags?ordering=name)
 [![GitHub last commit](https://img.shields.io/github/last-commit/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/pulls)
@@ -64,7 +64,7 @@ _The `-f` flag is optional and is used to follow the logs._
 
 All of the app data is stored in `/app/data`. The cache is stored in `/app/cache` or RAM, depending on the `RAM_CACHE` and `CACHE_DIR` environment variables.
 
-You can check the available tags on the [Docker Hub page](https://hub.docker.com/r/zbejas/orbiscast/tags).
+You can check the available tags on the [Docker Hub page](https://hub.docker.com/r/zbejas/orbiscast/tags?ordering=name).
 
 ### Manual
 

--- a/src/modules/commands.ts
+++ b/src/modules/commands.ts
@@ -1,6 +1,4 @@
 export { handleStreamCommand } from './commands/stream';
 export { handleStopCommand } from './commands/stop';
-export { handleJoinCommand } from './commands/join';
-export { handleLeaveCommand } from './commands/leave';
 export { handleListCommand } from './commands/list';
 export { handleRefreshCommand } from './commands/refresh';


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and modifications to the `src/modules/commands.ts` file. The changes are mainly focused on updating documentation links and cleaning up command exports.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4): Updated Docker Hub page links to include query parameter `ordering=name` for better tag ordering. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R67)

Codebase cleanup:

* [`src/modules/commands.ts`](diffhunk://#diff-c886911551c313fe8c1605774c16f49bbf81c00b8dc4ae230a46380531a1004eL3-L4): Removed unused command exports for `handleJoinCommand` and `handleLeaveCommand`.