### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The application uses the following environment variables, which should be define
 | Variable           | Description                                      | Example/Default                          | Required |
 |--------------------|--------------------------------------------------|------------------------------------------|----------|
 | `PLAYLIST`         | URL to the M3U playlist.                         | `http://example.com/m3u/playlist.m3u`    | ✔        |
-| `XMLTV`            | URL to the XMLTV guide.                          | `http://example.com/xmltv/guide.xml`     | ✔        |
+| `XMLTV`            | URL to the XMLTV guide. Can be an empty string.  | `http://example.com/xmltv/guide.xml`     | ✔        |
 | `REFRESH_IPTV`     | Interval in minutes to refresh the IPTV data.    | `1440`                                   | ✘        |
 | `RAM_CACHE`        | Whether to use RAM for caching.                  | `true`                                  | ✘        |
 | `CACHE_DIR`        | Directory for cache storage.                     | `../cache`                               | ✘        |
@@ -134,7 +134,7 @@ The bot can be controlled using the following commands:
 | Command | Description |
 |---------|-------------|
 | `/stream <channe>` | Start streaming the specified channel. |
-| `/programme <channel>` | Show the current programme for the specified channel. If no channel is all channels will be listed. |
+| `/programme <channel>` | Show the current programme for the specified channel. |
 | `/channels <page>` | List all available channels. Page is optional. |
 | `/stop` | Stop the current stream. |
 | `/refresh <type>` | Refresh the specified data. Type can be "all", "channels", or "programme". |


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to clarify environment variable usage and correct command descriptions. The most important changes are as follows:

### Environment Variable Clarifications:
* Updated the description of the `XMLTV` environment variable to indicate it can be an empty string, providing more flexibility in its configuration. (`README.md`, [README.mdL109-R109](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109))

### Command Description Updates:
* Simplified the description of the `/programme <channel>` command to remove ambiguity about listing all channels when no channel is specified. (`README.md`, [README.mdL137-R137](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R137))