### PR TITLE
fix: update README to correct link placement for public M3U playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The application uses the following environment variables, which should be define
 | `BITRATE_VIDEO_MAX`| Maximum video bitrate in Kbps.                   | `7500`                                   | ✘        |
 
 > [!TIP]
-> There is a bunch of IPTV providers online. I recommend using a tool like [Threadfin](https://github.com/Threadfin/Threadfin) or [Dispatcharr](https://github.com/Dispatcharr/Dispatcharr) to sort out your IPTV channels. You can find public M3U playlists on sites like [GitHub](https://github.com/iptv-org/iptv). More info on IPTV and can be found [here](https://github.com/iptv-org/awesome-iptv).
+> There is a bunch of IPTV providers online. I recommend using a tool like [Threadfin](https://github.com/Threadfin/Threadfin) or [Dispatcharr](https://github.com/Dispatcharr/Dispatcharr) to sort out your IPTV channels. You can find public M3U playlists [here](https://github.com/iptv-org/iptv). More info on IPTV and can be found [here](https://github.com/iptv-org/awesome-iptv).
 
 ### Discord Configuration
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change simplifies the description of where to find public M3U playlists by removing a redundant mention of GitHub and directly linking to the resource.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R121): Updated the tip about IPTV providers to streamline the text and improve clarity by consolidating the reference to public M3U playlists.