### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OrbisCast
 
-[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/main.yml?label=main%20build)](https://github.com/zbejas/orbiscast/actions/workflows/main.yml)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/master.yml?label=master%20build)](https://github.com/zbejas/orbiscast/actions/workflows/master.yml)
 [![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/dev.yml?label=dev%20build)](https://github.com/zbejas/orbiscast/actions/workflows/dev.yml)
 [![GitHub last commit](https://img.shields.io/github/last-commit/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/issues)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/master.yml?label=master%20build)](https://github.com/zbejas/orbiscast/actions/workflows/master.yml)
 [![GitHub build status](https://img.shields.io/github/actions/workflow/status/zbejas/orbiscast/dev.yml?label=dev%20build)](https://github.com/zbejas/orbiscast/actions/workflows/dev.yml)
-[![GitHub last commit](https://img.shields.io/github/last-commit/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/commits/main)
+[![GitHub last commit](https://img.shields.io/github/last-commit/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/commits/master)
 [![GitHub issues](https://img.shields.io/github/issues/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/pulls)
-[![GitHub license](https://img.shields.io/github/license/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/blob/main/LICENSE.md)
+[![GitHub license](https://img.shields.io/github/license/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/blob/master/LICENSE.md)
 [![Release](https://img.shields.io/github/v/release/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/releases)
 [![Repo size](https://img.shields.io/github/repo-size/zbejas/orbiscast)](https://github.com/zbejas/orbiscast/)
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/zbejas/orbiscast?sort=date)](https://hub.docker.com/r/zbejas/orbiscast)


### PR DESCRIPTION
This pull request updates the `README.md` file to use the `master` branch instead of `main` for several GitHub badge links. This ensures that the badges correctly reflect the status and information for the project's default branch.

* Updated badge URLs for build status, last commit, and license to reference the `master` branch instead of `main` in `README.md`.